### PR TITLE
full size photos on image preview tap

### DIFF
--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectRowComponents.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectRowComponents.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.semantics.contentDescription
@@ -56,10 +57,12 @@ internal fun ProjectImageOrCheckbox(
         )
     } else {
         project.imagePaths.firstOrNull()?.let { imagePath ->
+            val thumbnailSizePx = with(LocalDensity.current) { 100.dp.roundToPx() }
             AsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(imagePath)
                     .crossfade(true)
+                    .size(thumbnailSizePx)
                     .build(),
                 contentDescription = stringResource(R.string.cd_project_image),
                 placeholder = ColorPainter(placeholderColor),

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/projectDetail/ImagePreviewBottomSheet.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/projectDetail/ImagePreviewBottomSheet.kt
@@ -1,0 +1,177 @@
+package dev.harrisonsoftware.stitchCounter.feature.projectDetail
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import dev.harrisonsoftware.stitchCounter.R
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ImagePreviewBottomSheet(
+    imagePaths: List<String>,
+    initialPageIndex: Int,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val pagerState = rememberPagerState(
+        initialPage = initialPageIndex.coerceIn(0, (imagePaths.size - 1).coerceAtLeast(0)),
+        pageCount = { imagePaths.size }
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+    ) {
+        ImagePreviewTopBar(
+            currentPage = pagerState.currentPage + 1,
+            totalPages = imagePaths.size,
+            onClose = onDismiss
+        )
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            key = { imagePaths[it] }
+        ) { pageIndex ->
+            FullSizeProjectImage(
+                imagePath = imagePaths[pageIndex],
+                pageNumber = pageIndex + 1,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        if (imagePaths.size > 1) {
+            PageIndicatorRow(
+                currentPage = pagerState.currentPage,
+                pageCount = imagePaths.size,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImagePreviewTopBar(
+    currentPage: Int,
+    totalPages: Int,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(R.string.image_preview_page_indicator, currentPage, totalPages),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(start = 8.dp)
+        )
+        IconButton(
+            onClick = onClose,
+            modifier = Modifier.size(48.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.cd_close_image_preview),
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullSizeProjectImage(
+    imagePath: String,
+    pageNumber: Int,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val imageDescription = stringResource(R.string.cd_full_size_project_image, pageNumber)
+
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(imagePath)
+                .crossfade(true)
+                .build(),
+            contentDescription = imageDescription,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            contentScale = ContentScale.Fit
+        )
+    }
+}
+
+@Composable
+private fun PageIndicatorRow(
+    currentPage: Int,
+    pageCount: Int,
+    modifier: Modifier = Modifier
+) {
+    val indicatorDescription = stringResource(
+        R.string.cd_image_page_indicator,
+        currentPage + 1,
+        pageCount
+    )
+
+    Row(
+        modifier = modifier.semantics { contentDescription = indicatorDescription },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        repeat(pageCount) { index ->
+            val isSelected = index == currentPage
+            Box(
+                modifier = Modifier
+                    .padding(horizontal = 4.dp)
+                    .size(if (isSelected) 10.dp else 8.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (isSelected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    )
+            )
+        }
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/projectDetail/ProjectImageComponents.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/projectDetail/ProjectImageComponents.kt
@@ -47,6 +47,7 @@ fun ProjectImageSelector(
     imagePaths: List<String>,
     onImageClick: () -> Unit,
     onRemoveImage: (String) -> Unit,
+    onTapImage: (index: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val photoCount = imagePaths.size
@@ -102,9 +103,11 @@ fun ProjectImageSelector(
                                         modifier = Modifier.fillMaxWidth()
                                     )
                                 } else {
+                                    val imageIndex = imagePaths.indexOf(item)
                                     ProjectImageThumbnail(
                                         imagePath = item,
                                         onRemoveImage = { onRemoveImage(item) },
+                                        onTapImage = { onTapImage(imageIndex) },
                                         modifier = Modifier.fillMaxWidth()
                                     )
                                 }
@@ -124,6 +127,7 @@ fun ProjectImageSelector(
 private fun ProjectImageThumbnail(
     imagePath: String,
     onRemoveImage: () -> Unit,
+    onTapImage: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -142,7 +146,11 @@ private fun ProjectImageThumbnail(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(120.dp)
-                .clip(RoundedCornerShape(12.dp)),
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(
+                    role = Role.Image,
+                    onClick = onTapImage
+                ),
             contentScale = ContentScale.Crop
         )
         ProjectImageDeleteButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="add_another_photo">Add Another Photo</string>
     <string name="add_photo">Add Photo</string>
     <string name="photo_count_format">%1$d/%2$d</string>
+    <string name="image_preview_page_indicator">%1$d of %2$d</string>
 
     <!-- Row progress -->
     <string name="row_progress_format">%1$d/%2$d</string>
@@ -148,6 +149,10 @@
     <string name="cd_drag_handle">Drag handle</string>
     <string name="cd_loading">Loading</string>
     <string name="cd_project_photos_header">Project photos, %1$d of %2$d</string>
+    <string name="cd_close_image_preview">Close image preview</string>
+    <string name="cd_full_size_project_image">Full size project image %1$d</string>
+    <string name="cd_image_page_indicator">Image %1$d of %2$d</string>
+    <string name="cd_tap_to_preview_image">Tap to view full size</string>
     <string name="cd_support_the_app">Support the app</string>
     <string name="cd_support_the_app_hint">Opens the support page</string>
     <string name="cd_open_kofi">Opens Ko-Fi donation page in browser</string>


### PR DESCRIPTION
got it so the user can view a swipe-able carousel of project photos that are enlarged in a separate bottom sheet when they tap the photo preview