### PR TITLE
Bugfix/settings tab transition lag

### DIFF
--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/BottomNavigationLayout.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/BottomNavigationLayout.kt
@@ -13,14 +13,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavHostController
 
 
 @Composable
 fun BottomNavigationLayout(
     selectedTab: BottomNavTab,
-    onTabSelected: (BottomNavTab) -> Unit,
-    navController: NavHostController
+    onTabSelected: (BottomNavTab) -> Unit
 ) {
     AnimatedVisibility(
         visible = true,
@@ -35,7 +33,6 @@ fun BottomNavigationLayout(
     ) {
         BottomNavigationBar(
             selectedTab = selectedTab,
-            navController = navController,
             onTabSelected = onTabSelected
         )
     }
@@ -44,7 +41,6 @@ fun BottomNavigationLayout(
 @Composable
 private fun BottomNavigationBar(
     selectedTab: BottomNavTab,
-    navController: NavHostController,
     onTabSelected: (BottomNavTab) -> Unit
 ) {
     NavigationBar {
@@ -54,7 +50,6 @@ private fun BottomNavigationBar(
                 selected = selectedTab == tab,
                 onClick = {
                     onTabSelected(tab)
-                    navigateToDestination(navController, getDestinationForTab(tab))
                 },
                 icon = {
                     Icon(

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/NavigationRailLayout.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/NavigationRailLayout.kt
@@ -13,13 +13,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavHostController
 
 @Composable
 fun NavigationRailLayout(
     selectedTab: BottomNavTab,
-    onTabSelected: (BottomNavTab) -> Unit,
-    navController: NavHostController
+    onTabSelected: (BottomNavTab) -> Unit
 ) {
     AnimatedVisibility(
         visible = true,
@@ -34,7 +32,6 @@ fun NavigationRailLayout(
     ) {
         NavigationRailComponent(
             selectedTab = selectedTab,
-            navController = navController,
             onTabSelected = onTabSelected
         )
     }
@@ -43,7 +40,6 @@ fun NavigationRailLayout(
 @Composable
 private fun NavigationRailComponent(
     selectedTab: BottomNavTab,
-    navController: NavHostController,
     onTabSelected: (BottomNavTab) -> Unit
 ) {
     NavigationRail {
@@ -53,7 +49,6 @@ private fun NavigationRailComponent(
                 selected = selectedTab == tab,
                 onClick = {
                     onTabSelected(tab)
-                    navigateToDestination(navController, getDestinationForTab(tab))
                 },
                 icon = {
                     Icon(

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/RootNavigationScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/navigation/RootNavigationScreen.kt
@@ -40,8 +40,7 @@ fun RootNavigationScreen(viewModel: RootNavigationViewModel) {
             if (isCompact) {
                 BottomNavigationLayout(
                     selectedTab = selectedTab,
-                    onTabSelected = viewModel::selectTab,
-                    navController = navController
+                    onTabSelected = viewModel::selectTab
                 )
             }
         }
@@ -50,8 +49,7 @@ fun RootNavigationScreen(viewModel: RootNavigationViewModel) {
             if (!isCompact) {
                 NavigationRailLayout(
                     selectedTab = selectedTab,
-                    onTabSelected = viewModel::selectTab,
-                    navController = navController
+                    onTabSelected = viewModel::selectTab
                 )
             }
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/ExpandableSection.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/ExpandableSection.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,6 +40,7 @@ internal fun ScrollToRevealExpandedItem(
     itemIndex: Int,
     lazyListState: LazyListState
 ) {
+    val bottomRevealPaddingPx = with(LocalDensity.current) { 16.dp.toPx() }
     LaunchedEffect(isExpanded) {
         if (isExpanded) {
             val trackingStartTime = System.currentTimeMillis()
@@ -47,9 +49,11 @@ internal fun ScrollToRevealExpandedItem(
                 .collect { layoutInfo ->
                     val itemInfo = layoutInfo.visibleItemsInfo.find { it.index == itemIndex }
                     if (itemInfo != null) {
-                        val overflowBeyondViewport = (itemInfo.offset + itemInfo.size) - layoutInfo.viewportEndOffset
+                        val viewportEndOffsetWithPadding = layoutInfo.viewportEndOffset - bottomRevealPaddingPx
+                        val overflowBeyondViewport =
+                            (itemInfo.offset + itemInfo.size).toFloat() - viewportEndOffsetWithPadding
                         if (overflowBeyondViewport > 0) {
-                            lazyListState.scrollBy(overflowBeyondViewport.toFloat())
+                            lazyListState.scrollBy(overflowBeyondViewport)
                         }
                     }
                 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
@@ -48,7 +48,7 @@ fun SettingsScreen(
     
     val context = LocalContext.current
     val showImportDialog = remember { mutableStateOf(false) }
-    val isThemeSectionExpanded = remember { mutableStateOf(true) }
+    val isThemeSectionExpanded = remember { mutableStateOf(false) }
     val isBackupSectionExpanded = remember { mutableStateOf(false) }
     val isSupportSectionExpanded = remember { mutableStateOf(false) }
     val isLegalSectionExpanded = remember { mutableStateOf(false) }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
@@ -90,7 +90,6 @@ fun SettingsScreen(
         }
     }
 
-    ScrollToRevealExpandedItem(isThemeSectionExpanded.value, 0, lazyListState)
     ScrollToRevealExpandedItem(isBackupSectionExpanded.value, 1, lazyListState)
     ScrollToRevealExpandedItem(isSupportSectionExpanded.value, 2, lazyListState)
     ScrollToRevealExpandedItem(isLegalSectionExpanded.value, 3, lazyListState)
@@ -98,6 +97,7 @@ fun SettingsScreen(
     Surface {
         LazyColumn(
             state = lazyListState,
+            contentPadding = PaddingValues(vertical = 16.dp),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(start = 16.dp, end = 16.dp, top = 16.dp),


### PR DESCRIPTION
fixed the lag by 
- collapsing the theme selection card by default 
- fixed some double navigation

also fixed some padding with the setting screen list and items