### PR TITLE
Feature/backup changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application
         android:name=".StitchCounterApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsBackupComponents.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsBackupComponents.kt
@@ -102,6 +102,12 @@ internal fun BackupRestoreCard(
                     style = MaterialTheme.typography.bodySmall
                 )
             }
+
+            Text(
+                text = stringResource(R.string.settings_backup_local_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
         }
     }
 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/supportApp/SupportAppScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/supportApp/SupportAppScreen.kt
@@ -193,6 +193,7 @@ fun SupportAppScreen(
                 enter = expandVertically() + fadeIn(),
                 exit = shrinkVertically() + fadeOut()
             ) {
+                val thankYouDescription = stringResource(R.string.cd_thank_you_for_support)
                 Card(
                     shape = RoundedCornerShape(20.dp),
                     colors = CardDefaults.cardColors(
@@ -210,7 +211,7 @@ fun SupportAppScreen(
                             modifier = Modifier
                                 .size(100.dp)
                                 .semantics {
-                                    contentDescription = "Heart decoration"
+                                    contentDescription = thankYouDescription
                                 }
                         )
                         Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="settings_export_library">Export Library</string>
     <string name="settings_importing">Importing…</string>
     <string name="settings_import_library">Import Library</string>
+    <string name="settings_backup_local_note">Data is stored locally; use Export to back up.</string>
     <string name="settings_error_file_access_unavailable">Can\'t access the selected file or location. Try choosing another file or location.</string>
     <string name="settings_error_storage_unavailable">Storage is unavailable. Check available storage and try again.</string>
     <string name="settings_error_backup_invalid">Backup file is incomplete or invalid.</string>
@@ -184,6 +185,7 @@
     <string name="cd_support_the_app">Support the app</string>
     <string name="cd_support_the_app_hint">Opens the support page</string>
     <string name="cd_open_kofi">Opens Ko-Fi donation page in browser</string>
+    <string name="cd_thank_you_for_support">Thank you for your support!</string>
     <string name="cd_i_supported_on">I supported toggle, currently on</string>
     <string name="cd_i_supported_off">I supported toggle, currently off</string>
 </resources>


### PR DESCRIPTION
Add persisted first-launch backup notice flow in Library, disable Android auto-backup for local-only data, and refresh backup guidance/accessibility copy with ViewModel test coverage.