### PR TITLE
Feature/additional settings

### DIFF
--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/MainActivity.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import android.content.res.Configuration
@@ -49,7 +50,10 @@ class MainActivity : ComponentActivity() {
             val configuration = LocalConfiguration.current
             val isWideLayout = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
             
-            StitchCounterV3Theme(theme = themeUiState.selectedTheme) {
+            StitchCounterV3Theme(
+                darkTheme = themeUiState.resolveDarkTheme(isSystemInDarkTheme()),
+                theme = themeUiState.selectedTheme
+            ) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     RootNavigationScreen(
                         viewModel = rootNavigationViewModel,

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/data/repo/AppPreferencesRepository.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/data/repo/AppPreferencesRepository.kt
@@ -44,6 +44,50 @@ class AppPreferencesRepository @Inject constructor(
 
     // endregion
 
+    // region Display
+
+    private val forceDarkModeKey = booleanPreferencesKey("force_dark_mode")
+    private val forceLightModeKey = booleanPreferencesKey("force_light_mode")
+    private val forceCounterScreensOnKey = booleanPreferencesKey("force_counter_screens_on")
+
+    val forceDarkMode: Flow<Boolean> = context.appDataStore.data.map { preferences ->
+        preferences[forceDarkModeKey] ?: false
+    }
+
+    val forceLightMode: Flow<Boolean> = context.appDataStore.data.map { preferences ->
+        preferences[forceLightModeKey] ?: false
+    }
+
+    val forceCounterScreensOn: Flow<Boolean> = context.appDataStore.data.map { preferences ->
+        preferences[forceCounterScreensOnKey] ?: false
+    }
+
+    suspend fun setForceDarkMode(enabled: Boolean) {
+        context.appDataStore.edit { preferences ->
+            preferences[forceDarkModeKey] = enabled
+            if (enabled) {
+                preferences[forceLightModeKey] = false
+            }
+        }
+    }
+
+    suspend fun setForceLightMode(enabled: Boolean) {
+        context.appDataStore.edit { preferences ->
+            preferences[forceLightModeKey] = enabled
+            if (enabled) {
+                preferences[forceDarkModeKey] = false
+            }
+        }
+    }
+
+    suspend fun setForceCounterScreensOn(enabled: Boolean) {
+        context.appDataStore.edit { preferences ->
+            preferences[forceCounterScreensOnKey] = enabled
+        }
+    }
+
+    // endregion
+
     // region Support
 
     private val hasSupportedKey = booleanPreferencesKey("has_supported_app")

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterScreen.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.harrisonsoftware.stitchCounter.R
 import dev.harrisonsoftware.stitchCounter.feature.navigation.RootNavGraph
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.AdaptiveLayout
+import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.KeepScreenOnEffect
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.ProjectDetailsFAB
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.ResetConfirmationDialog
 import com.ramcosta.composedestinations.annotation.Destination
@@ -62,6 +63,7 @@ fun DoubleCounterScreen(
     }
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    KeepScreenOnEffect(enabled = state.forceCounterScreensOn)
     
     val context = LocalContext.current
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterViewModel.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterViewModel.kt
@@ -34,6 +34,7 @@ data class DoubleCounterUiState(
     val totalRows: Int = 0,
     val totalStitchesEver: Int = 0,
     val shouldShowCustomAdjustmentTip: Boolean = false,
+    val forceCounterScreensOn: Boolean = false,
     val activeCustomAdjustmentDialogCounterType: CounterType? = null,
     val customAdjustmentDialogInput: String = "",
 ) {
@@ -81,9 +82,20 @@ open class DoubleCounterViewModel @Inject constructor(
     private var persistJob: Job? = null
 
     init {
+        observeForceCounterScreensOn()
         viewModelScope.launch {
             if (appPreferencesRepository.consumeShouldShowCustomAdjustmentTip()) {
                 showCustomAdjustmentTip()
+            }
+        }
+    }
+
+    private fun observeForceCounterScreensOn() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceCounterScreensOn.collect { forceCounterScreensOn ->
+                _uiState.update { currentState ->
+                    currentState.copy(forceCounterScreensOn = forceCounterScreensOn)
+                }
             }
         }
     }
@@ -97,7 +109,9 @@ open class DoubleCounterViewModel @Inject constructor(
                 return@launch
             }
             if (_uiState.value.id != projectId) {
-                _uiState.update { DoubleCounterUiState() }
+                _uiState.update { currentState ->
+                    DoubleCounterUiState(forceCounterScreensOn = currentState.forceCounterScreensOn)
+                }
             }
             val project = getProject(projectId)
             if (project != null) {
@@ -196,6 +210,7 @@ open class DoubleCounterViewModel @Inject constructor(
                         ),
                         totalRows = project.totalRows,
                         totalStitchesEver = restoredTotalStitchesEver,
+                        forceCounterScreensOn = current.forceCounterScreensOn,
                         activeCustomAdjustmentDialogCounterType = current.activeCustomAdjustmentDialogCounterType,
                         customAdjustmentDialogInput = current.customAdjustmentDialogInput
                     )
@@ -306,7 +321,9 @@ open class DoubleCounterViewModel @Inject constructor(
     }
 
     fun resetState() {
-        _uiState.update { _ -> DoubleCounterUiState() }
+        _uiState.update { currentState ->
+            DoubleCounterUiState(forceCounterScreensOn = currentState.forceCounterScreensOn)
+        }
         clearSavedState()
     }
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/BackupComponents.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/BackupComponents.kt
@@ -44,6 +44,11 @@ internal fun BackupRestoreCard(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            Text(
+                text = stringResource(R.string.settings_export_import_library),
+                style = MaterialTheme.typography.titleMedium
+            )
+
             Button(
                 onClick = onExport,
                 enabled = !isExporting && !isImporting,

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/LegalCard.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/LegalCard.kt
@@ -8,9 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BugReport
-import androidx.compose.material.icons.filled.Feedback
-import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.LocalPolice
 import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material3.Button
@@ -25,69 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dev.harrisonsoftware.stitchCounter.R
-
-@Composable
-internal fun SupportCard(
-    onReportBug: () -> Unit,
-    onGiveFeedback: () -> Unit,
-    onRequestFeature: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-        colors = CardDefaults.cardColors().copy(containerColor = MaterialTheme.colorScheme.primaryContainer)
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Button(
-                onClick = onReportBug,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(
-                    imageVector = Icons.Default.BugReport,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.settings_report_bug))
-            }
-
-            Button(
-                onClick = onGiveFeedback,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondary
-                )
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Feedback,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.settings_give_feedback))
-            }
-
-            Button(
-                onClick = onRequestFeature,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
-                )
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Lightbulb,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.settings_request_feature))
-            }
-        }
-    }
-}
 
 @Composable
 internal fun LegalCard(

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsCard.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsCard.kt
@@ -1,33 +1,36 @@
 package dev.harrisonsoftware.stitchCounter.feature.settings
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BugReport
-import androidx.compose.material.icons.filled.Feedback
-import androidx.compose.material.icons.filled.Lightbulb
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import dev.harrisonsoftware.stitchCounter.R
 
 @Composable
 internal fun SettingsCard(
+    forceDarkMode: Boolean,
+    onForceDarkModeChange: (Boolean) -> Unit,
+    forceLightMode: Boolean,
+    onForceLightModeChange: (Boolean) -> Unit,
+    forceCounterScreensOn: Boolean,
+    onForceCounterScreensOnChange: (Boolean) -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -38,14 +41,78 @@ internal fun SettingsCard(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Row {
-                Text(stringResource(R.string.settings_dark_mode))
-                Spacer(modifier = Modifier.weight(1f))
-                Switch(
-                    checked = ,
-                    onCheckChanged =
-                )
-            }
+            SettingsSwitchRow(
+                titleRes = R.string.settings_dark_mode,
+                subtitleRes = R.string.settings_dark_mode_subtitle,
+                checked = forceDarkMode,
+                onCheckedChange = onForceDarkModeChange
+            )
+            SettingsSwitchRow(
+                titleRes = R.string.settings_light_mode,
+                subtitleRes = R.string.settings_light_mode_subtitle,
+                checked = forceLightMode,
+                onCheckedChange = onForceLightModeChange
+            )
+            SettingsSwitchRow(
+                titleRes = R.string.settings_force_counter_screens_on,
+                subtitleRes = R.string.settings_force_counter_screens_on_subtitle,
+                checked = forceCounterScreensOn,
+                onCheckedChange = onForceCounterScreensOnChange
+            )
         }
+    }
+}
+
+@Composable
+private fun SettingsSwitchRow(
+    @StringRes titleRes: Int,
+    @StringRes subtitleRes: Int,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    val title = stringResource(titleRes)
+    val stateDescription = stringResource(
+        if (checked) {
+            R.string.cd_setting_on
+        } else {
+            R.string.cd_setting_off
+        }
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = onCheckedChange
+            )
+            .semantics(mergeDescendants = true) {
+                this.stateDescription = stateDescription
+            }
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Text(
+                text = stringResource(subtitleRes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f)
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
+            modifier = Modifier.clearAndSetSemantics {}
+        )
     }
 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsCard.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsCard.kt
@@ -1,0 +1,51 @@
+package dev.harrisonsoftware.stitchCounter.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Feedback
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.harrisonsoftware.stitchCounter.R
+
+@Composable
+internal fun SettingsCard(
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors().copy(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row {
+                Text(stringResource(R.string.settings_dark_mode))
+                Spacer(modifier = Modifier.weight(1f))
+                Switch(
+                    checked = ,
+                    onCheckChanged =
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
@@ -5,8 +5,10 @@ import android.content.ClipData
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -56,11 +58,21 @@ fun SettingsScreen(
     val showImportDialog = remember { mutableStateOf(false) }
     val showBugReportDialog = remember { mutableStateOf(false) }
     val includeDiagnosticsForCurrentBugReport = rememberSaveable { mutableStateOf(true) }
-    val isThemeSectionExpanded = remember { mutableStateOf(false) }
-    val isBackupSectionExpanded = remember { mutableStateOf(false) }
-    val isSupportSectionExpanded = remember { mutableStateOf(false) }
-    val isLegalSectionExpanded = remember { mutableStateOf(false) }
+    val settingsSections = remember { SettingsScreenSection.entries.toList() }
+    val expandedSectionNames = rememberSaveable { mutableStateOf(emptyList<String>()) }
     val lazyListState = rememberLazyListState()
+
+    fun isSectionExpanded(section: SettingsScreenSection): Boolean {
+        return section.name in expandedSectionNames.value
+    }
+
+    fun updateSectionExpanded(section: SettingsScreenSection, isExpanded: Boolean) {
+        expandedSectionNames.value = updatedExpandedSettingsSectionNames(
+            expandedSectionNames = expandedSectionNames.value,
+            sectionName = section.name,
+            isExpanded = isExpanded
+        )
+    }
     
     LaunchedEffect(uiState.exportSuccess) {
         if (uiState.exportSuccess) {
@@ -114,9 +126,9 @@ fun SettingsScreen(
         }
     }
 
-    ScrollToRevealExpandedItem(isBackupSectionExpanded.value, 1, lazyListState)
-    ScrollToRevealExpandedItem(isSupportSectionExpanded.value, 2, lazyListState)
-    ScrollToRevealExpandedItem(isLegalSectionExpanded.value, 3, lazyListState)
+    settingsSections.forEachIndexed { index, section ->
+        ScrollToRevealExpandedItem(isSectionExpanded(section), index, lazyListState)
+    }
 
     Surface {
         LazyColumn(
@@ -127,97 +139,78 @@ fun SettingsScreen(
                 .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            item {
-                ExpandableSection(
-                    title = stringResource(R.string.settings_theme),
-                    isExpanded = isThemeSectionExpanded.value,
-                    onToggleExpanded = { isThemeSectionExpanded.value = !isThemeSectionExpanded.value }
-                ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                        Text(
-                            text = stringResource(R.string.settings_choose_color_scheme),
-                            style = MaterialTheme.typography.titleMedium
-                        )
 
-                        AppTheme.entries.forEach { theme ->
-                            ThemeOptionCard(
-                                theme = theme,
-                                isSelected = uiState.selectedTheme == theme,
-                                themeColors = if (uiState.selectedTheme == theme) uiState.themeColors else emptyList(),
-                                onThemeSelected = { viewModel.onThemeSelected(theme) }
+            items(
+                items = settingsSections,
+                key = { sectionType -> sectionType.name }
+            ) { sectionType ->
+                SettingsSection(
+                    sectionName = stringResource(sectionType.titleId),
+                    isExpanded = isSectionExpanded(sectionType),
+                    updateExpanded = { newIsExpanded ->
+                        updateSectionExpanded(sectionType, newIsExpanded)
+                    }
+                ) {
+                    when (sectionType) {
+                        SettingsScreenSection.THEME -> {
+                            ThemeCard(
+                                themeColors = uiState.themeColors,
+                                selectedTheme = uiState.selectedTheme,
+                                updateTheme = { newTheme ->
+                                    viewModel.onThemeSelected(newTheme)
+                            })
+                        }
+                        SettingsScreenSection.SETTINGS -> {
+                            SettingsCard(
+
+                            )
+                        }
+                        SettingsScreenSection.BACKUP_RESTORE -> {
+                            BackupRestoreCard(
+                                isExporting = uiState.isExporting,
+                                isImporting = uiState.isImporting,
+                                exportError = uiState.exportError,
+                                importError = uiState.importError,
+                                onExport = {
+                                    viewModel.onLaunchingExternalActivity()
+                                    val timestamp = java.text.SimpleDateFormat(
+                                        "yyyyMMdd_HHmmss",
+                                        java.util.Locale.US
+                                    )
+                                        .format(java.util.Date())
+                                    exportLauncher.launch("stitch_counter_backup_$timestamp.zip")
+                                },
+                                onImport = {
+                                    viewModel.onLaunchingExternalActivity()
+                                    importLauncher.launch("application/zip")
+                                }
+                            )
+                        }
+                        SettingsScreenSection.SUPPORT -> {
+                            SupportCard(
+                                onReportBug = {
+                                    includeDiagnosticsForCurrentBugReport.value = true
+                                    showBugReportDialog.value = true
+                                },
+                                onGiveFeedback = {
+                                    viewModel.onGiveFeedback()
+                                },
+                                onRequestFeature = {
+                                    viewModel.onRequestFeature()
+                                }
+                            )
+                        }
+                        SettingsScreenSection.LEGAL -> {
+                            LegalCard(
+                                onOpenPrivacyPolicy = {
+                                    viewModel.onOpenPrivacyPolicy()
+                                },
+                                onOpenEULA = {
+                                    viewModel.onOpenEULA()
+                                }
                             )
                         }
                     }
-                }
-            }
-
-            item {
-                ExpandableSection(
-                    title = stringResource(R.string.settings_backup_restore),
-                    isExpanded = isBackupSectionExpanded.value,
-                    onToggleExpanded = { isBackupSectionExpanded.value = !isBackupSectionExpanded.value }
-                ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                        Text(
-                            text = stringResource(R.string.settings_export_import_library),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-
-                        BackupRestoreCard(
-                            isExporting = uiState.isExporting,
-                            isImporting = uiState.isImporting,
-                            exportError = uiState.exportError,
-                            importError = uiState.importError,
-                            onExport = {
-                                viewModel.onLaunchingExternalActivity()
-                                val timestamp = java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.US)
-                                    .format(java.util.Date())
-                                exportLauncher.launch("stitch_counter_backup_$timestamp.zip")
-                            },
-                            onImport = {
-                                viewModel.onLaunchingExternalActivity()
-                                importLauncher.launch("application/zip")
-                            }
-                        )
-                    }
-                }
-            }
-
-            item {
-                ExpandableSection(
-                    title = stringResource(R.string.settings_support),
-                    isExpanded = isSupportSectionExpanded.value,
-                    onToggleExpanded = { isSupportSectionExpanded.value = !isSupportSectionExpanded.value }
-                ) {
-                    SupportCard(
-                        onReportBug = {
-                            includeDiagnosticsForCurrentBugReport.value = true
-                            showBugReportDialog.value = true
-                        },
-                        onGiveFeedback = {
-                            viewModel.onGiveFeedback()
-                        },
-                        onRequestFeature = {
-                            viewModel.onRequestFeature()
-                        }
-                    )
-                }
-            }
-
-            item {
-                ExpandableSection(
-                    title = stringResource(R.string.settings_privacy_legal),
-                    isExpanded = isLegalSectionExpanded.value,
-                    onToggleExpanded = { isLegalSectionExpanded.value = !isLegalSectionExpanded.value }
-                ) {
-                    LegalCard(
-                        onOpenPrivacyPolicy = {
-                            viewModel.onOpenPrivacyPolicy()
-                        },
-                        onOpenEULA = {
-                            viewModel.onOpenEULA()
-                        }
-                    )
                 }
             }
         }
@@ -284,6 +277,30 @@ fun SettingsScreen(
     }
 }
 
+private enum class SettingsScreenSection(@param:StringRes val titleId: Int) {
+    THEME(R.string.settings_theme),
+    SETTINGS(R.string.nav_settings),
+    BACKUP_RESTORE(R.string.settings_backup_restore),
+    SUPPORT(R.string.settings_support),
+    LEGAL(R.string.settings_privacy_legal)
+}
+
+internal fun updatedExpandedSettingsSectionNames(
+    expandedSectionNames: List<String>,
+    sectionName: String,
+    isExpanded: Boolean
+): List<String> {
+    return if (isExpanded) {
+        if (sectionName in expandedSectionNames) {
+            expandedSectionNames
+        } else {
+            expandedSectionNames + sectionName
+        }
+    } else {
+        expandedSectionNames - sectionName
+    }
+}
+
 internal fun launchExternalActivitySafely(context: android.content.Context, intent: Intent): Boolean {
     return runCatching { context.startActivity(intent) }
         .fold(
@@ -333,4 +350,19 @@ private fun launchBugReportWithAttachment(
         }
         false
     }
+}
+
+@Composable
+private fun SettingsSection(
+    sectionName: String,
+    isExpanded: Boolean,
+    updateExpanded: (isExpanded: Boolean) -> Unit,
+    content: @Composable () -> Unit
+) {
+    ExpandableSection(
+        title = sectionName,
+        isExpanded = isExpanded,
+        onToggleExpanded = { updateExpanded(!isExpanded) },
+        content = content
+    )
 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -131,19 +132,20 @@ fun SettingsScreen(
     }
 
     Surface {
-        LazyColumn(
-            state = lazyListState,
-            contentPadding = PaddingValues(vertical = 16.dp),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 16.dp, end = 16.dp, top = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-
-            items(
-                items = settingsSections,
-                key = { sectionType -> sectionType.name }
-            ) { sectionType ->
+        Column(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                state = lazyListState,
+                contentPadding = PaddingValues(top = 16.dp, bottom = 8.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(
+                    items = settingsSections,
+                    key = { sectionType -> sectionType.name }
+                ) { sectionType ->
                 SettingsSection(
                     sectionName = stringResource(sectionType.titleId),
                     isExpanded = isSectionExpanded(sectionType),
@@ -162,7 +164,12 @@ fun SettingsScreen(
                         }
                         SettingsScreenSection.SETTINGS -> {
                             SettingsCard(
-
+                                forceDarkMode = uiState.forceDarkMode,
+                                onForceDarkModeChange = viewModel::onForceDarkModeChanged,
+                                forceLightMode = uiState.forceLightMode,
+                                onForceLightModeChange = viewModel::onForceLightModeChanged,
+                                forceCounterScreensOn = uiState.forceCounterScreensOn,
+                                onForceCounterScreensOnChange = viewModel::onForceCounterScreensOnChanged
                             )
                         }
                         SettingsScreenSection.BACKUP_RESTORE -> {
@@ -213,6 +220,9 @@ fun SettingsScreen(
                     }
                 }
             }
+            }
+
+            SettingsAppVersionLabel(appVersion = uiState.appVersion)
         }
 
         if (showImportDialog.value) {
@@ -350,6 +360,22 @@ private fun launchBugReportWithAttachment(
         }
         false
     }
+}
+
+@Composable
+private fun SettingsAppVersionLabel(
+    appVersion: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = stringResource(R.string.settings_app_version, appVersion),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    )
 }
 
 @Composable

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsViewModel.kt
@@ -40,9 +40,10 @@ class SettingsViewModel @Inject constructor(
     private val exportLibraryUseCase: ExportLibrary,
     private val importLibraryUseCase: ImportLibrary,
     private val bugReportLogPackager: BugReportLogPackager,
+    appVersion: String,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(SettingsUiState())
+    private val _uiState = MutableStateFlow(SettingsUiState(appVersion = appVersion))
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     private val _effect = Channel<SettingsEffect>(Channel.BUFFERED)
@@ -50,6 +51,9 @@ class SettingsViewModel @Inject constructor(
 
     init {
         observeTheme()
+        observeForceDarkMode()
+        observeForceLightMode()
+        observeForceCounterScreensOn()
     }
 
     private fun observeTheme() {
@@ -69,6 +73,54 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             appPreferencesRepository.setTheme(theme)
             launcherIconManager.pendingTheme = theme
+        }
+    }
+
+    private fun observeForceDarkMode() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceDarkMode.collect { forceDarkMode ->
+                _uiState.update { currentState ->
+                    currentState.copy(forceDarkMode = forceDarkMode)
+                }
+            }
+        }
+    }
+
+    private fun observeForceLightMode() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceLightMode.collect { forceLightMode ->
+                _uiState.update { currentState ->
+                    currentState.copy(forceLightMode = forceLightMode)
+                }
+            }
+        }
+    }
+
+    private fun observeForceCounterScreensOn() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceCounterScreensOn.collect { forceCounterScreensOn ->
+                _uiState.update { currentState ->
+                    currentState.copy(forceCounterScreensOn = forceCounterScreensOn)
+                }
+            }
+        }
+    }
+
+    fun onForceDarkModeChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            appPreferencesRepository.setForceDarkMode(enabled)
+        }
+    }
+
+    fun onForceLightModeChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            appPreferencesRepository.setForceLightMode(enabled)
+        }
+    }
+
+    fun onForceCounterScreensOnChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            appPreferencesRepository.setForceCounterScreensOn(enabled)
         }
     }
 
@@ -225,8 +277,12 @@ private fun ImportLibraryError.toUserMessage(): SettingsUiText = when (this) {
 }
 
 data class SettingsUiState(
+    val appVersion: String = "",
     val selectedTheme: AppTheme = AppTheme.FOREST_FIBER,
     val themeColors: List<ThemeColor> = emptyList(),
+    val forceDarkMode: Boolean = false,
+    val forceLightMode: Boolean = false,
+    val forceCounterScreensOn: Boolean = false,
     val isExporting: Boolean = false,
     val exportSuccess: Boolean = false,
     val exportError: SettingsUiText? = null,

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SupportCard.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/SupportCard.kt
@@ -1,0 +1,88 @@
+package dev.harrisonsoftware.stitchCounter.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Feedback
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.harrisonsoftware.stitchCounter.R
+
+@Composable
+internal fun SupportCard(
+    onReportBug: () -> Unit,
+    onGiveFeedback: () -> Unit,
+    onRequestFeature: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors().copy(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(
+                onClick = onReportBug,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Default.BugReport,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.settings_report_bug))
+            }
+
+            Button(
+                onClick = onGiveFeedback,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Feedback,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.settings_give_feedback))
+            }
+
+            Button(
+                onClick = onRequestFeature,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.tertiary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Lightbulb,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.settings_request_feature))
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/ThemeCard.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/settings/ThemeCard.kt
@@ -1,0 +1,34 @@
+package dev.harrisonsoftware.stitchCounter.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.harrisonsoftware.stitchCounter.R
+import dev.harrisonsoftware.stitchCounter.domain.model.AppTheme
+import dev.harrisonsoftware.stitchCounter.feature.theme.ThemeColor
+
+@Composable
+fun ThemeCard(selectedTheme: AppTheme,
+              updateTheme: (theme: AppTheme) -> Unit,
+              themeColors: List<ThemeColor>
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = stringResource(R.string.settings_choose_color_scheme),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        AppTheme.entries.forEach { theme ->
+            ThemeOptionCard(
+                theme = theme,
+                isSelected = selectedTheme == theme,
+                themeColors = if (selectedTheme == theme) themeColors else emptyList(),
+                onThemeSelected = { updateTheme(theme) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/KeepScreenOnEffect.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/KeepScreenOnEffect.kt
@@ -1,0 +1,22 @@
+package dev.harrisonsoftware.stitchCounter.feature.sharedComposables
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalView
+
+@Composable
+fun KeepScreenOnEffect(enabled: Boolean) {
+    val view = LocalView.current
+
+    DisposableEffect(view, enabled) {
+        if (enabled) {
+            view.keepScreenOn = true
+        }
+
+        onDispose {
+            if (enabled) {
+                view.keepScreenOn = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterScreen.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterScreen.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.harrisonsoftware.stitchCounter.R
 import dev.harrisonsoftware.stitchCounter.feature.navigation.RootNavGraph
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.AdaptiveLayout
+import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.KeepScreenOnEffect
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.ProjectDetailsFAB
 import dev.harrisonsoftware.stitchCounter.feature.sharedComposables.ResetConfirmationDialog
 import com.ramcosta.composedestinations.annotation.Destination
@@ -62,6 +63,7 @@ fun SingleCounterScreen(
     }
     
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    KeepScreenOnEffect(enabled = state.forceCounterScreensOn)
     
     val context = LocalContext.current
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterViewModel.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterViewModel.kt
@@ -32,6 +32,7 @@ data class SingleCounterUiState(
     val counterState: CounterState = CounterState(),
     val totalStitchesEver: Int = 0,
     val shouldShowCustomAdjustmentTip: Boolean = false,
+    val forceCounterScreensOn: Boolean = false,
     val customAdjustmentDialogState: CustomAdjustmentDialogState = CustomAdjustmentDialogState(),
 )
 
@@ -59,9 +60,20 @@ open class SingleCounterViewModel @Inject constructor(
     private var persistJob: Job? = null
 
     init {
+        observeForceCounterScreensOn()
         viewModelScope.launch {
             if (appPreferencesRepository.consumeShouldShowCustomAdjustmentTip()) {
                 showCustomAdjustmentTip()
+            }
+        }
+    }
+
+    private fun observeForceCounterScreensOn() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceCounterScreensOn.collect { forceCounterScreensOn ->
+                _uiState.update { currentState ->
+                    currentState.copy(forceCounterScreensOn = forceCounterScreensOn)
+                }
             }
         }
     }
@@ -75,7 +87,9 @@ open class SingleCounterViewModel @Inject constructor(
                 return@launch
             }
             if (_uiState.value.id != projectId) {
-                _uiState.update { SingleCounterUiState() }
+                _uiState.update { currentState ->
+                    SingleCounterUiState(forceCounterScreensOn = currentState.forceCounterScreensOn)
+                }
             }
             val project = getProject(projectId)
             if (project != null) {
@@ -134,6 +148,7 @@ open class SingleCounterViewModel @Inject constructor(
                             customAdjustmentAmount = restoredCustomAdjustmentAmount
                         ),
                         totalStitchesEver = restoredTotalStitchesEver,
+                        forceCounterScreensOn = current.forceCounterScreensOn,
                         customAdjustmentDialogState = current.customAdjustmentDialogState
                     )
                 }
@@ -232,7 +247,9 @@ open class SingleCounterViewModel @Inject constructor(
     }
 
     fun resetState() {
-        _uiState.update { _ -> SingleCounterUiState() }
+        _uiState.update { currentState ->
+            SingleCounterUiState(forceCounterScreensOn = currentState.forceCounterScreensOn)
+        }
         clearSavedState()
     }
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/theme/ThemeViewModel.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/theme/ThemeViewModel.kt
@@ -22,6 +22,8 @@ class ThemeViewModel @Inject constructor(
 
     init {
         observeTheme()
+        observeForceDarkMode()
+        observeForceLightMode()
     }
 
     private fun observeTheme() {
@@ -31,8 +33,32 @@ class ThemeViewModel @Inject constructor(
             }
         }
     }
+
+    private fun observeForceDarkMode() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceDarkMode.collect { forceDarkMode ->
+                _uiState.update { currentState -> currentState.copy(forceDarkMode = forceDarkMode) }
+            }
+        }
+    }
+
+    private fun observeForceLightMode() {
+        viewModelScope.launch {
+            appPreferencesRepository.forceLightMode.collect { forceLightMode ->
+                _uiState.update { currentState -> currentState.copy(forceLightMode = forceLightMode) }
+            }
+        }
+    }
 }
 
 data class ThemeUiState(
-    val selectedTheme: AppTheme = AppTheme.FOREST_FIBER
-)
+    val selectedTheme: AppTheme = AppTheme.FOREST_FIBER,
+    val forceDarkMode: Boolean = false,
+    val forceLightMode: Boolean = false,
+) {
+    fun resolveDarkTheme(systemInDarkTheme: Boolean): Boolean = when {
+        forceDarkMode -> true
+        forceLightMode -> false
+        else -> systemInDarkTheme
+    }
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/BugReportLogPackager.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/BugReportLogPackager.kt
@@ -122,7 +122,11 @@ class BugReportLogPackager @Inject constructor(
     ): File {
         val outputFileName = "${logFile.nameWithoutExtension}.html"
         val outputFile = File(outputDirectory, outputFileName)
-        val escapedLogContent = runCatching { logFile.readText() }.getOrDefault("").escapeHtml()
+        val logContentWithAppVersion = addAppVersionToFile(
+            logFileContent = runCatching { logFile.readText() }.getOrDefault(""),
+            appVersion = metadata.appVersion
+        )
+        val escapedLogContent = logContentWithAppVersion.escapeHtml()
 
         val html = buildString {
             append("<!doctype html><html><head><meta charset=\"utf-8\">")

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/DiagnosticLogFormatter.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/DiagnosticLogFormatter.kt
@@ -1,0 +1,56 @@
+package dev.harrisonsoftware.stitchCounter.logging
+
+internal const val LOG_APP_VERSION_PREFIX = "app="
+
+internal fun formatLogLine(
+    timestamp: String,
+    levelLabel: String,
+    tag: String,
+    appVersion: String,
+    message: String,
+    throwable: Throwable? = null
+): String {
+    val sanitizedMessage = message.replace("\n", "\\n")
+    return buildString {
+        append(timestamp)
+        append(" | ")
+        append(levelLabel)
+        append(" | ")
+        append(tag)
+        append(" | ")
+        append(LOG_APP_VERSION_PREFIX)
+        append(appVersion)
+        append(" | ")
+        append(sanitizedMessage)
+        if (throwable != null) {
+            append(" | throwable=")
+            append(throwable::class.java.simpleName)
+            append(":")
+            append(throwable.message ?: "no_message")
+        }
+    }
+}
+
+internal fun logLineHasAppVersion(logLine: String): Boolean {
+    return logLine.contains(" | $LOG_APP_VERSION_PREFIX")
+}
+
+internal fun addAppVersionToLine(logLine: String, appVersion: String): String {
+    if (logLine.isBlank()) return logLine
+    if (logLineHasAppVersion(logLine)) return logLine
+
+    val fields = logLine.split(" | ", limit = 4)
+    return if (fields.size == 4) {
+        "${fields[0]} | ${fields[1]} | ${fields[2]} | " +
+            "$LOG_APP_VERSION_PREFIX$appVersion | ${fields[3]}"
+    } else {
+        "$LOG_APP_VERSION_PREFIX$appVersion | $logLine"
+    }
+}
+
+internal fun addAppVersionToFile(logFileContent: String, appVersion: String): String {
+    return logFileContent
+        .lineSequence()
+        .map { line -> addAppVersionToLine(line, appVersion) }
+        .joinToString("\n")
+}

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/TimberFileLogTree.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/logging/TimberFileLogTree.kt
@@ -25,6 +25,7 @@ private const val LOG_DIRECTORY_NAME = "logs"
 class TimberFileLogTree @Inject constructor(
     private val fileSystemProvider: FileSystemProvider,
     private val logRetentionPolicy: LogRetentionPolicy,
+    private val appVersion: String,
 ) : Timber.Tree() {
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val commandChannel = Channel<TimberLogTreeCommand>(Channel.UNLIMITED)
@@ -99,22 +100,14 @@ class TimberFileLogTree @Inject constructor(
 
     private fun appendLogEntry(entry: TimberLogEntry) {
         val logFile = File(resolveLogDirectory(), buildFileName(entry.timestampEpochMillis))
-        val sanitizedMessage = entry.message.replace("\n", "\\n")
-        val logLine = buildString {
-            append(Instant.ofEpochMilli(entry.timestampEpochMillis).toString())
-            append(" | ")
-            append(LogPriorityFormatter.toLabel(entry.priority))
-            append(" | ")
-            append(entry.tag)
-            append(" | ")
-            append(sanitizedMessage)
-            if (entry.throwable != null) {
-                append(" | throwable=")
-                append(entry.throwable::class.java.simpleName)
-                append(":")
-                append(entry.throwable.message ?: "no_message")
-            }
-        }
+        val logLine = formatLogLine(
+            timestamp = Instant.ofEpochMilli(entry.timestampEpochMillis).toString(),
+            levelLabel = LogPriorityFormatter.toLabel(entry.priority),
+            tag = entry.tag,
+            appVersion = appVersion,
+            message = entry.message,
+            throwable = entry.throwable
+        )
         logFile.appendText("$logLine\n")
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,10 +104,16 @@
     <string name="settings_bug_report_dialog_send">Send Bug Report</string>
     <string name="settings_give_feedback">Give Feedback</string>
     <string name="settings_dark_mode">Dark Mode</string>
+    <string name="settings_dark_mode_subtitle">Always use dark mode, regardless of system settings.</string>
+    <string name="settings_light_mode">Light Mode</string>
+    <string name="settings_light_mode_subtitle">Always use light mode, regardless of system settings.</string>
+    <string name="settings_force_counter_screens_on">Keep Counter Screens Awake</string>
+    <string name="settings_force_counter_screens_on_subtitle">Keeps the screen on while you count.</string>
     <string name="settings_request_feature">Request a Feature</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_eula">EULA</string>
     <string name="settings_eula_description">By using Stitch Counter, you agree to the EULA.</string>
+    <string name="settings_app_version">Version %1$s</string>
     <string name="settings_import_complete">Import Complete</string>
     <string name="settings_imported_count">Imported %1$d project(s)</string>
     <string name="settings_failed_import_count">Failed to import %1$d project(s)</string>
@@ -189,4 +195,6 @@
     <string name="cd_thank_you_for_support">Thank you for your support!</string>
     <string name="cd_i_supported_on">I supported toggle, currently on</string>
     <string name="cd_i_supported_off">I supported toggle, currently off</string>
+    <string name="cd_setting_on">On</string>
+    <string name="cd_setting_off">Off</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="settings_bug_report_dialog_include_diagnostics">Include diagnostics logs</string>
     <string name="settings_bug_report_dialog_send">Send Bug Report</string>
     <string name="settings_give_feedback">Give Feedback</string>
+    <string name="settings_dark_mode">Dark Mode</string>
     <string name="settings_request_feature">Request a Feature</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_eula">EULA</string>

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/data/repo/AppPreferencesRepositoryTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/data/repo/AppPreferencesRepositoryTest.kt
@@ -1,0 +1,92 @@
+package dev.harrisonsoftware.stitchCounter.data.repo
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AppPreferencesRepositoryTest {
+
+    private lateinit var repository: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        repository = AppPreferencesRepository(RuntimeEnvironment.getApplication())
+    }
+
+    @After
+    fun tearDown() = runTest {
+        repository.setForceDarkMode(false)
+        repository.setForceLightMode(false)
+        repository.setForceCounterScreensOn(false)
+    }
+
+    @Test
+    fun `forceDarkMode defaults to false`() = runTest {
+        assertFalse(repository.forceDarkMode.first())
+    }
+
+    @Test
+    fun `forceLightMode defaults to false`() = runTest {
+        assertFalse(repository.forceLightMode.first())
+    }
+
+    @Test
+    fun `forceCounterScreensOn defaults to false`() = runTest {
+        assertFalse(repository.forceCounterScreensOn.first())
+    }
+
+    @Test
+    fun `setForceDarkMode true persists and disables force light mode`() = runTest {
+        repository.setForceLightMode(true)
+        repository.setForceDarkMode(true)
+
+        assertTrue(repository.forceDarkMode.first())
+        assertFalse(repository.forceLightMode.first())
+    }
+
+    @Test
+    fun `setForceDarkMode false persists`() = runTest {
+        repository.setForceDarkMode(true)
+        repository.setForceDarkMode(false)
+
+        assertFalse(repository.forceDarkMode.first())
+    }
+
+    @Test
+    fun `setForceLightMode true persists and disables force dark mode`() = runTest {
+        repository.setForceDarkMode(true)
+        repository.setForceLightMode(true)
+
+        assertTrue(repository.forceLightMode.first())
+        assertFalse(repository.forceDarkMode.first())
+    }
+
+    @Test
+    fun `setForceLightMode false persists`() = runTest {
+        repository.setForceLightMode(true)
+        repository.setForceLightMode(false)
+
+        assertFalse(repository.forceLightMode.first())
+    }
+
+    @Test
+    fun `setForceCounterScreensOn persists on and off`() = runTest {
+        repository.setForceCounterScreensOn(true)
+        assertTrue(repository.forceCounterScreensOn.first())
+
+        repository.setForceCounterScreensOn(false)
+        assertFalse(repository.forceCounterScreensOn.first())
+    }
+}

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterViewModelTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/doublecounter/DoubleCounterViewModelTest.kt
@@ -11,9 +11,11 @@ import dev.harrisonsoftware.stitchCounter.domain.usecase.GetProject
 import dev.harrisonsoftware.stitchCounter.domain.usecase.UpdateDoubleCounterValues
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -42,6 +44,7 @@ class DoubleCounterViewModelTest {
         getProject = mockk()
         updateDoubleCounterValues = mockk(relaxed = true)
         appPreferencesRepository = mockk()
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(false)
         coEvery { appPreferencesRepository.consumeShouldShowCustomAdjustmentTip() } returns false
     }
 
@@ -78,6 +81,26 @@ class DoubleCounterViewModelTest {
         assertEquals(0, state.stitchCounterState.count)
         assertEquals(0, state.rowCounterState.count)
         assertEquals(0, state.totalRows)
+    }
+
+    @Test
+    fun `init observes keep screen on`() {
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(true)
+        val viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value.forceCounterScreensOn)
+    }
+
+    @Test
+    fun `resetState keeps screen on preference`() = runTest {
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(true)
+        coEvery { getProject(1) } returns sampleProject()
+
+        val viewModel = createViewModel()
+        viewModel.loadProject(1)
+        viewModel.resetState()
+
+        assertTrue(viewModel.uiState.value.forceCounterScreensOn)
     }
 
     @Test

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsScreenTest.kt
@@ -7,6 +7,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -35,5 +36,38 @@ class SettingsScreenTest {
 
         assertFalse(wasLaunched)
         verify(exactly = 1) { context.startActivity(intent) }
+    }
+
+    @Test
+    fun `updatedExpandedSettingsSectionNames adds section without removing already expanded sections`() {
+        val expandedSections = updatedExpandedSettingsSectionNames(
+            expandedSectionNames = listOf("THEME"),
+            sectionName = "SUPPORT",
+            isExpanded = true
+        )
+
+        assertEquals(listOf("THEME", "SUPPORT"), expandedSections)
+    }
+
+    @Test
+    fun `updatedExpandedSettingsSectionNames does not duplicate an expanded section`() {
+        val expandedSections = updatedExpandedSettingsSectionNames(
+            expandedSectionNames = listOf("THEME", "SUPPORT"),
+            sectionName = "SUPPORT",
+            isExpanded = true
+        )
+
+        assertEquals(listOf("THEME", "SUPPORT"), expandedSections)
+    }
+
+    @Test
+    fun `updatedExpandedSettingsSectionNames removes only the collapsed section`() {
+        val expandedSections = updatedExpandedSettingsSectionNames(
+            expandedSectionNames = listOf("THEME", "SUPPORT", "LEGAL"),
+            sectionName = "SUPPORT",
+            isExpanded = false
+        )
+
+        assertEquals(listOf("THEME", "LEGAL"), expandedSections)
     }
 }

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/settings/SettingsViewModelTest.kt
@@ -19,6 +19,7 @@ import dev.harrisonsoftware.stitchCounter.feature.theme.ThemeManager
 import dev.harrisonsoftware.stitchCounter.logging.BugReportLogPackager
 import dev.harrisonsoftware.stitchCounter.logging.BugReportLogPackagerResult
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -58,6 +59,9 @@ class SettingsViewModelTest {
         importLibrary = mockk()
         bugReportLogPackager = mockk()
         every { appPreferencesRepository.selectedTheme } returns flowOf(AppTheme.FOREST_FIBER)
+        every { appPreferencesRepository.forceDarkMode } returns flowOf(false)
+        every { appPreferencesRepository.forceLightMode } returns flowOf(false)
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(false)
         every { themeManager.getThemeColors(any()) } returns emptyList()
     }
 
@@ -66,18 +70,35 @@ class SettingsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = SettingsViewModel(
+    private fun createViewModel(appVersion: String = "1.0.0.6") = SettingsViewModel(
         appPreferencesRepository = appPreferencesRepository,
         themeManager = themeManager,
         launcherIconManager = launcherIconManager,
         exportLibraryUseCase = exportLibrary,
         importLibraryUseCase = importLibrary,
         bugReportLogPackager = bugReportLogPackager,
+        appVersion = appVersion,
     )
+
+    @Test
+    fun `ui state shows app version`() {
+        val viewModel = createViewModel(appVersion = "2.0.0")
+
+        assertEquals("2.0.0", viewModel.uiState.value.appVersion)
+    }
 
     @Test
     fun `settings ui state defaults to forest fiber theme`() {
         assertEquals(AppTheme.FOREST_FIBER, SettingsUiState().selectedTheme)
+    }
+
+    @Test
+    fun `display toggles default to off`() {
+        val state = SettingsUiState()
+
+        assertFalse(state.forceDarkMode)
+        assertFalse(state.forceLightMode)
+        assertFalse(state.forceCounterScreensOn)
     }
 
     @Test
@@ -86,6 +107,84 @@ class SettingsViewModelTest {
         val viewModel = createViewModel()
 
         assertEquals(AppTheme.SEA_COTTAGE, viewModel.uiState.value.selectedTheme)
+    }
+
+    @Test
+    fun `init observes force dark mode`() {
+        every { appPreferencesRepository.forceDarkMode } returns flowOf(true)
+        val viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value.forceDarkMode)
+    }
+
+    @Test
+    fun `init observes force light mode`() {
+        every { appPreferencesRepository.forceLightMode } returns flowOf(true)
+        val viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value.forceLightMode)
+    }
+
+    @Test
+    fun `init observes keep screen on`() {
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(true)
+        val viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value.forceCounterScreensOn)
+    }
+
+    @Test
+    fun `onForceDarkModeChanged calls setForceDarkMode when true`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceDarkModeChanged(true)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceDarkMode(true) }
+    }
+
+    @Test
+    fun `onForceDarkModeChanged calls setForceDarkMode when false`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceDarkModeChanged(false)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceDarkMode(false) }
+    }
+
+    @Test
+    fun `onForceLightModeChanged calls setForceLightMode when true`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceLightModeChanged(true)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceLightMode(true) }
+    }
+
+    @Test
+    fun `onForceLightModeChanged calls setForceLightMode when false`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceLightModeChanged(false)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceLightMode(false) }
+    }
+
+    @Test
+    fun `onForceCounterScreensOnChanged calls setForceCounterScreensOn when true`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceCounterScreensOnChanged(true)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceCounterScreensOn(true) }
+    }
+
+    @Test
+    fun `onForceCounterScreensOnChanged calls setForceCounterScreensOn when false`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onForceCounterScreensOnChanged(false)
+
+        coVerify(exactly = 1) { appPreferencesRepository.setForceCounterScreensOn(false) }
     }
 
     @Test

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterViewModelTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/singleCounter/SingleCounterViewModelTest.kt
@@ -12,9 +12,11 @@ import dev.harrisonsoftware.stitchCounter.domain.usecase.GetProject
 import dev.harrisonsoftware.stitchCounter.domain.usecase.UpdateSingleCounterValues
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -42,6 +44,7 @@ class SingleCounterViewModelTest {
         getProject = mockk()
         updateSingleCounterValues = mockk(relaxed = true)
         appPreferencesRepository = mockk()
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(false)
         coEvery { appPreferencesRepository.consumeShouldShowCustomAdjustmentTip() } returns false
     }
 
@@ -78,6 +81,27 @@ class SingleCounterViewModelTest {
         assertEquals(0, state.id)
         assertEquals(0, state.counterState.count)
         assertEquals(AdjustmentAmount.ONE, state.counterState.adjustment)
+    }
+
+    @Test
+    fun `init observes keep screen on`() {
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(true)
+        val viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value.forceCounterScreensOn)
+    }
+
+    @Test
+    fun `resetState keeps screen on preference`() = runTest {
+        every { appPreferencesRepository.forceCounterScreensOn } returns flowOf(true)
+        val project = sampleProject()
+        coEvery { getProject(1) } returns project
+
+        val viewModel = createViewModel()
+        viewModel.loadProject(1)
+        viewModel.resetState()
+
+        assertTrue(viewModel.uiState.value.forceCounterScreensOn)
     }
 
     @Test

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/theme/ThemeViewModelTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/theme/ThemeViewModelTest.kt
@@ -1,0 +1,85 @@
+package dev.harrisonsoftware.stitchCounter.feature.theme
+
+import dev.harrisonsoftware.stitchCounter.data.repo.AppPreferencesRepository
+import dev.harrisonsoftware.stitchCounter.domain.model.AppTheme
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThemeViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var appPreferencesRepository: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        appPreferencesRepository = mockk()
+        every { appPreferencesRepository.selectedTheme } returns flowOf(AppTheme.FOREST_FIBER)
+        every { appPreferencesRepository.forceDarkMode } returns flowOf(false)
+        every { appPreferencesRepository.forceLightMode } returns flowOf(false)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `init observes selected theme`() {
+        every { appPreferencesRepository.selectedTheme } returns flowOf(AppTheme.SEA_COTTAGE)
+        val viewModel = ThemeViewModel(appPreferencesRepository)
+
+        assertEquals(AppTheme.SEA_COTTAGE, viewModel.uiState.value.selectedTheme)
+    }
+
+    @Test
+    fun `init observes force dark mode`() {
+        every { appPreferencesRepository.forceDarkMode } returns flowOf(true)
+        val viewModel = ThemeViewModel(appPreferencesRepository)
+
+        assertTrue(viewModel.uiState.value.forceDarkMode)
+    }
+
+    @Test
+    fun `init observes force light mode`() {
+        every { appPreferencesRepository.forceLightMode } returns flowOf(true)
+        val viewModel = ThemeViewModel(appPreferencesRepository)
+
+        assertTrue(viewModel.uiState.value.forceLightMode)
+    }
+
+    @Test
+    fun `resolveDarkTheme uses forced dark mode when enabled`() {
+        val themeUiState = ThemeUiState(forceDarkMode = true, forceLightMode = false)
+
+        assertTrue(themeUiState.resolveDarkTheme(systemInDarkTheme = false))
+    }
+
+    @Test
+    fun `resolveDarkTheme uses forced light mode when enabled`() {
+        val themeUiState = ThemeUiState(forceDarkMode = false, forceLightMode = true)
+
+        assertFalse(themeUiState.resolveDarkTheme(systemInDarkTheme = true))
+    }
+
+    @Test
+    fun `resolveDarkTheme follows system when neither mode is forced`() {
+        val themeUiState = ThemeUiState(forceDarkMode = false, forceLightMode = false)
+
+        assertTrue(themeUiState.resolveDarkTheme(systemInDarkTheme = true))
+        assertFalse(themeUiState.resolveDarkTheme(systemInDarkTheme = false))
+    }
+}

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/BugReportLogPackagerTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/BugReportLogPackagerTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -24,7 +25,11 @@ class BugReportLogPackagerTest {
         val expectedHtmlFileName = "app-log-$retentionCurrentDate.html"
 
         val fileSystemProvider = FakeFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         val logDirectory = fileLogTree.resolveLogDirectory()
         File(logDirectory, logFileName).writeText(
             "2026-03-13T10:00:00.000Z | INFO | SCProjectData | delete_bulk_start count=2"
@@ -50,6 +55,47 @@ class BugReportLogPackagerTest {
             assertTrue(htmlContent.contains("Android version:</strong> 14"))
             assertTrue(htmlContent.contains("Device model:</strong> Pixel Test"))
             assertTrue(htmlContent.contains("SCProjectData"))
+            assertTrue(htmlContent.contains("| app=3.2.1 | delete_bulk_start count=2"))
+        }
+    }
+
+    @Test
+    fun `packageLogsAsHtmlZip stamps app version on legacy log lines`() = runTest {
+        val filesDirectory = Files.createTempDirectory("bug_report_line_version_files").toFile()
+        val cacheDirectory = Files.createTempDirectory("bug_report_line_version_cache").toFile()
+        val retentionCurrentDate = LocalDate.of(2026, 3, 13)
+        val logFileName = "app-log-$retentionCurrentDate.log"
+
+        val fileSystemProvider = FakeFileSystemProvider(filesDirectory, cacheDirectory)
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
+        val logDirectory = fileLogTree.resolveLogDirectory()
+        File(logDirectory, logFileName).writeText(
+            """
+            2026-03-13T10:00:00.000Z | INFO | SCProjectData | legacy_event
+            2026-03-13T10:00:01.000Z | WARN | SCProjectData | app=1.0.0.6 | current_event
+            """.trimIndent()
+        )
+        val packager = BugReportLogPackager(
+            fileLogTree = fileLogTree,
+            fileSystemProvider = fileSystemProvider,
+            deviceMetadataProvider = FakeDeviceMetadataProvider()
+        )
+
+        val result = packager.packageLogsAsHtmlZip(retentionCurrentDate = retentionCurrentDate)
+
+        assertTrue(result is BugReportLogPackagerResult.Success)
+        val zipFile = (result as BugReportLogPackagerResult.Success).zipFile
+        ZipFile(zipFile).use { diagnosticsZip ->
+            val htmlContent = diagnosticsZip.entries().asSequence()
+                .map { diagnosticsZip.getInputStream(it).bufferedReader().readText() }
+                .first()
+            assertTrue(htmlContent.contains("| app=3.2.1 | legacy_event"))
+            assertTrue(htmlContent.contains("| app=1.0.0.6 | current_event"))
+            assertFalse(htmlContent.contains("| app=3.2.1 | app=1.0.0.6"))
         }
     }
 
@@ -58,7 +104,11 @@ class BugReportLogPackagerTest {
         val filesDirectory = Files.createTempDirectory("bug_report_latest_log_files").toFile()
         val cacheDirectory = Files.createTempDirectory("bug_report_latest_log_cache").toFile()
         val fileSystemProvider = FakeFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         Timber.plant(fileLogTree)
         val packager = BugReportLogPackager(
             fileLogTree = fileLogTree,
@@ -75,7 +125,7 @@ class BugReportLogPackagerTest {
         ZipFile(zipFile).use { diagnosticsZip ->
             val entry = diagnosticsZip.entries().asSequence().first()
             val htmlContent = diagnosticsZip.getInputStream(entry).bufferedReader().readText()
-            assertTrue(htmlContent.contains("latest_log_before_packaging"))
+            assertTrue(htmlContent.contains("| app=1.0.0.6 | latest_log_before_packaging"))
         }
         Timber.uproot(fileLogTree)
     }
@@ -85,7 +135,11 @@ class BugReportLogPackagerTest {
         val filesDirectory = Files.createTempDirectory("bug_report_no_logs_files").toFile()
         val cacheDirectory = Files.createTempDirectory("bug_report_no_logs_cache").toFile()
         val fileSystemProvider = FakeFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         val packager = BugReportLogPackager(
             fileLogTree = fileLogTree,
             fileSystemProvider = fileSystemProvider,
@@ -102,7 +156,11 @@ class BugReportLogPackagerTest {
         val filesDirectory = Files.createTempDirectory("bug_report_concurrent_log_files").toFile()
         val cacheDirectory = Files.createTempDirectory("bug_report_concurrent_log_cache").toFile()
         val fileSystemProvider = FakeFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         Timber.plant(fileLogTree)
         val packager = BugReportLogPackager(
             fileLogTree = fileLogTree,

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/DiagnosticLogFormatterTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/DiagnosticLogFormatterTest.kt
@@ -1,0 +1,65 @@
+package dev.harrisonsoftware.stitchCounter.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiagnosticLogFormatterTest {
+
+    @Test
+    fun `formatLogLine includes app version`() {
+        val line = formatLogLine(
+            timestamp = "2026-03-13T10:00:00.000Z",
+            levelLabel = "INFO",
+            tag = "SCProjectData",
+            appVersion = "1.0.0.6",
+            message = "delete_bulk_start count=2"
+        )
+
+        assertEquals(
+            "2026-03-13T10:00:00.000Z | INFO | SCProjectData | app=1.0.0.6 | delete_bulk_start count=2",
+            line
+        )
+    }
+
+    @Test
+    fun `addAppVersionToLine fills legacy line`() {
+        val legacyLine = "2026-03-13T10:00:00.000Z | INFO | SCProjectData | delete_bulk_start count=2"
+
+        val stampedLine = addAppVersionToLine(legacyLine, appVersion = "3.2.1")
+
+        assertEquals(
+            "2026-03-13T10:00:00.000Z | INFO | SCProjectData | app=3.2.1 | delete_bulk_start count=2",
+            stampedLine
+        )
+    }
+
+    @Test
+    fun `addAppVersionToLine skips line that already has version`() {
+        val lineWithVersion =
+            "2026-03-13T10:00:00.000Z | INFO | SCProjectData | app=1.0.0.6 | delete_bulk_start count=2"
+
+        val stampedLine = addAppVersionToLine(lineWithVersion, appVersion = "9.9.9")
+
+        assertEquals(lineWithVersion, stampedLine)
+    }
+
+    @Test
+    fun `addAppVersionToFile stamps each line`() {
+        val logFileContent = """
+            2026-03-13T10:00:00.000Z | INFO | SCProjectData | first_event
+            2026-03-13T10:00:01.000Z | WARN | SCProjectData | app=1.0.0.6 | already_has_version
+
+        """.trimIndent()
+
+        val stampedContent = addAppVersionToFile(
+            logFileContent = logFileContent,
+            appVersion = "3.2.1"
+        )
+
+        assertTrue(stampedContent.contains("| app=3.2.1 | first_event"))
+        assertTrue(stampedContent.contains("| app=1.0.0.6 | already_has_version"))
+        assertFalse(stampedContent.contains("| app=3.2.1 | app=1.0.0.6"))
+    }
+}

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/TimberFileLogTreeTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/logging/TimberFileLogTreeTest.kt
@@ -16,7 +16,11 @@ class TimberFileLogTreeTest {
         val filesDirectory = Files.createTempDirectory("file_log_sink_files").toFile()
         val cacheDirectory = Files.createTempDirectory("file_log_sink_cache").toFile()
         val fileSystemProvider = TestFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         Timber.plant(fileLogTree)
 
         Timber.tag("TestTag").d("debug_entry_should_not_persist")
@@ -32,9 +36,9 @@ class TimberFileLogTreeTest {
             .joinToString("\n") { it.readText() }
 
         assertFalse(persistedContent.contains("debug_entry_should_not_persist"))
-        assertTrue(persistedContent.contains("info_entry_should_persist"))
-        assertTrue(persistedContent.contains("warn_entry_should_persist"))
-        assertTrue(persistedContent.contains("error_entry_should_persist"))
+        assertTrue(persistedContent.contains("| app=1.0.0.6 | info_entry_should_persist"))
+        assertTrue(persistedContent.contains("| app=1.0.0.6 | warn_entry_should_persist"))
+        assertTrue(persistedContent.contains("| app=1.0.0.6 | error_entry_should_persist"))
         Timber.uproot(fileLogTree)
     }
 
@@ -43,7 +47,11 @@ class TimberFileLogTreeTest {
         val filesDirectory = Files.createTempDirectory("file_log_sync_files").toFile()
         val cacheDirectory = Files.createTempDirectory("file_log_sync_cache").toFile()
         val fileSystemProvider = TestFileSystemProvider(filesDirectory, cacheDirectory)
-        val fileLogTree = TimberFileLogTree(fileSystemProvider, LogRetentionPolicy())
+        val fileLogTree = TimberFileLogTree(
+            fileSystemProvider = fileSystemProvider,
+            logRetentionPolicy = LogRetentionPolicy(),
+            appVersion = "1.0.0.6"
+        )
         Timber.plant(fileLogTree)
 
         Timber.tag("TestTag").i("entry_before_sync_packaging")
@@ -55,7 +63,7 @@ class TimberFileLogTreeTest {
             .orEmpty()
             .joinToString("\n") { it.readText() }
 
-        assertTrue(persistedContent.contains("entry_before_sync_packaging"))
+        assertTrue(persistedContent.contains("| app=1.0.0.6 | entry_before_sync_packaging"))
         Timber.uproot(fileLogTree)
     }
 }


### PR DESCRIPTION
- Refactors the settings screen into smaller cards (ThemeCard, SettingsCard, SupportCard, LegalCard, backup components) for easier maintenance.
- Adds DataStore-backed toggles for force dark mode, force light mode, and keep counter screens awake; theme and counter screens respect these prefs.
- Shows app version on the settings screen and includes it in file log lines and bug report HTML (via DiagnosticLogFormatter).
- Adds unit tests for prefs persistence, settings/theme view models, counter keep-awake behavior, and logging formatters.