### PR TITLE
Hotfix/haptics

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application
         android:name=".StitchCounterApp"
         android:allowBackup="false"

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/Constants.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/Constants.kt
@@ -16,6 +16,7 @@ object Constants {
     const val LOG_TAG_LAUNCHER_ICON_MANAGER = "LauncherIconManager"
     const val LOG_TAG_TIMBER_FILE_LOG_TREE = "SCTimberFileLogTree"
     const val LOG_TAG_IMAGE_SAVE = "ImageSave"
+    const val LOG_TAG_COUNTER_HAPTIC = "CounterHaptic"
     const val PRIVACY_POLICY_URL = "https://harrisonsoftware.dev/stitch-counter-v2/privacy-policy"
     const val EULA_URL = "https://harrisonsoftware.dev/stitch-counter-v2/eula"
     const val KOFI_URL = "https://ko-fi.com/annaharri"

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/notes/CreateNoteViewModel.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/notes/CreateNoteViewModel.kt
@@ -54,7 +54,13 @@ class CreateNoteViewModel @Inject constructor(
     fun loadNote(noteId: Int?) {
         viewModelScope.launch {
             if (noteId == null) {
+                if (shouldPreserveCreateDraft(_uiState.value)) {
+                    return@launch
+                }
                 resetToCreateMode()
+                return@launch
+            }
+            if (shouldPreserveEditDraft(_uiState.value, noteId)) {
                 return@launch
             }
             _uiState.update { currentState ->
@@ -128,6 +134,7 @@ class CreateNoteViewModel @Inject constructor(
     }
 
     fun confirmDiscard() {
+        resetToCreateMode()
         viewModelScope.launch { _dismissalResult.send(DismissalResult.Allowed) }
     }
 
@@ -196,6 +203,15 @@ class CreateNoteViewModel @Inject constructor(
         originalBody = ""
         _uiState.value = CreateNoteUiState()
     }
+
+    private fun shouldPreserveCreateDraft(currentState: CreateNoteUiState): Boolean =
+        !currentState.isEditMode && !currentState.isSaved && currentState.loadError == null
+
+    private fun shouldPreserveEditDraft(currentState: CreateNoteUiState, noteId: Int): Boolean =
+        currentState.noteId == noteId &&
+            !currentState.isSaved &&
+            currentState.loadError == null &&
+            !currentState.isLoading
 
     private fun hasUnsavedChanges(currentState: CreateNoteUiState): Boolean {
         if (currentState.isEditMode) {

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/rowandrepeat/RowAndRepeatComponents.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/rowandrepeat/RowAndRepeatComponents.kt
@@ -378,7 +378,11 @@ private fun DashedCorrectionButton(
 ) {
     val strokeColor = MaterialTheme.colorScheme.outline
     val shape = RoundedCornerShape(50)
-    val label = stringResource(R.string.row_and_repeat_correct_repeat_button)
+    val label = if (isExpanded) {
+        stringResource(R.string.row_and_repeat_hide_correct_repeat_button)
+    } else {
+        stringResource(R.string.row_and_repeat_correct_repeat_button)
+    }
     val expandedStateDescription =
         stringResource(R.string.cd_row_and_repeat_correct_repeat_expanded)
     val collapsedStateDescription =

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/AdaptiveLayout.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/AdaptiveLayout.kt
@@ -2,19 +2,21 @@ package dev.harrisonsoftware.stitchCounter.feature.sharedComposables
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
 fun AdaptiveLayout(
     isWideLayout: Boolean,
     portraitContent: @Composable ColumnScope.() -> Unit,
-    landscapeContent: @Composable RowScope.() -> Unit
+    landscapeContent: @Composable ColumnScope.() -> Unit
 ) {
-    if (isWideLayout) {
-        Row(content = landscapeContent)
-    } else {
-        Column(content = portraitContent)
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (isWideLayout) {
+            landscapeContent()
+        } else {
+            portraitContent()
+        }
     }
 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterHapticFeedback.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterHapticFeedback.kt
@@ -1,14 +1,24 @@
 package dev.harrisonsoftware.stitchCounter.feature.sharedComposables
 
-import android.view.HapticFeedbackConstants
+import android.content.Context
+import android.os.Build
+import android.os.VibrationAttributes
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.provider.Settings
 import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalView
+import dev.harrisonsoftware.stitchCounter.Constants
+import timber.log.Timber
 
 val LocalCounterHapticFeedbackEnabled = compositionLocalOf { true }
+
+private const val COUNTER_CLICK_VIBRATION_DURATION_MS = 40L
 
 @Composable
 fun CounterHapticFeedbackProvider(
@@ -20,9 +30,63 @@ fun CounterHapticFeedbackProvider(
     }
 }
 
-fun performCounterButtonHapticFeedback(view: View, enabled: Boolean) {
-    if (enabled) {
-        view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
+fun performCounterButtonHapticFeedback(
+    view: View,
+    enabled: Boolean,
+    clickVibration: (Context) -> Unit = ::performClickVibration,
+) {
+    if (!enabled) {
+        return
+    }
+    clickVibration(view.context)
+}
+
+internal fun performClickVibration(context: Context) {
+    runCatching {
+        if (!isSystemHapticFeedbackEnabled(context)) {
+            return
+        }
+        val vibrator = context.defaultVibrator() ?: return
+        if (!vibrator.hasVibrator()) {
+            return
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(COUNTER_CLICK_VIBRATION_DURATION_MS)
+            return
+        }
+        val effect = VibrationEffect.createOneShot(
+            COUNTER_CLICK_VIBRATION_DURATION_MS,
+            VibrationEffect.DEFAULT_AMPLITUDE,
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val attributes = VibrationAttributes.Builder()
+                .setUsage(VibrationAttributes.USAGE_TOUCH)
+                .build()
+            vibrator.vibrate(effect, attributes)
+        } else {
+            vibrator.vibrate(effect)
+        }
+    }.onFailure { error ->
+        Timber.tag(Constants.LOG_TAG_COUNTER_HAPTIC)
+            .w(error, "event=vibrator_failed")
+    }
+}
+
+@Suppress("DEPRECATION")
+internal fun isSystemHapticFeedbackEnabled(context: Context): Boolean {
+    return Settings.System.getInt(
+        context.contentResolver,
+        Settings.System.HAPTIC_FEEDBACK_ENABLED,
+        1,
+    ) != 0
+}
+
+private fun Context.defaultVibrator(): Vibrator? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        getSystemService(VibratorManager::class.java)?.defaultVibrator
+    } else {
+        getSystemService(Vibrator::class.java)
     }
 }
 

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterTopBar.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterTopBar.kt
@@ -17,6 +17,7 @@ fun CounterTopBar(
     modifier: Modifier = Modifier,
     title: String,
     topBarContent: (@Composable () -> Unit)? = null,
+    compact: Boolean = false,
 ) {
     if (title.isNotEmpty() || topBarContent != null) {
         Row(
@@ -28,7 +29,11 @@ fun CounterTopBar(
             if (title.isNotEmpty()) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.titleMedium,
+                    style = if (compact) {
+                        MaterialTheme.typography.titleSmall
+                    } else {
+                        MaterialTheme.typography.titleMedium
+                    },
                     modifier = Modifier.weight(1f)
                 )
             } else {

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/ProjectDetailsFAB.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/ProjectDetailsFAB.kt
@@ -16,19 +16,23 @@ import dev.harrisonsoftware.stitchCounter.R
 @Composable
 fun ProjectDetailsFAB(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
 ) {
+    val fabSize = if (compact) 32.dp else 40.dp
+    val iconSize = if (compact) 16.dp else 20.dp
+    val startPadding = if (compact) 8.dp else 16.dp
     FloatingActionButton(
         onClick = onClick,
         modifier = modifier
-            .padding(start = 16.dp)
-            .size(40.dp),
+            .padding(start = startPadding)
+            .size(fabSize),
         containerColor = MaterialTheme.colorScheme.primaryContainer
     ) {
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = stringResource(R.string.cd_project_details),
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(iconSize)
         )
     }
 }

--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/ResizableText.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/ResizableText.kt
@@ -22,6 +22,7 @@ import kotlin.math.min
 fun ResizableText(
     text: String,
     modifier: Modifier = Modifier,
+    sizingReferenceText: String? = null,
     heightRatio: Float = 0.8f,
     widthRatio: Float = 0.4f,
     minFontSize: Float = 48f,
@@ -29,6 +30,8 @@ fun ResizableText(
     fontWeight: FontWeight = FontWeight.Bold,
     textAlign: TextAlign = TextAlign.Center
 ) {
+    val textForSizing = sizingReferenceText ?: text
+
     BoxWithConstraints(
         modifier = modifier
     ) {
@@ -55,7 +58,7 @@ fun ResizableText(
         
         val absoluteMinFontSize = minFontSize * 0.5f
         
-        val fontSize = remember(text, maxTextWidth, maxTextHeight, initialFontSize, minFontSize, maxFontSize, fontWeight, baseTypography) {
+        val fontSize = remember(textForSizing, maxTextWidth, maxTextHeight, initialFontSize, minFontSize, maxFontSize, fontWeight, baseTypography) {
             var currentSize = initialFontSize
             val baseStyle = TextStyle(
                 fontSize = baseTypography.fontSize,
@@ -75,7 +78,7 @@ fun ResizableText(
                 val textStyle = baseStyle.copy(fontSize = testSize.sp)
                 
                 val textLayoutResult = textMeasurer.measure(
-                    text = text,
+                    text = textForSizing,
                     style = textStyle,
                     constraints = Constraints(maxWidth = Int.MAX_VALUE)
                 )
@@ -97,7 +100,7 @@ fun ResizableText(
                 val textStyle = baseStyle.copy(fontSize = currentSize.sp)
                 
                 val textLayoutResult = textMeasurer.measure(
-                    text = text,
+                    text = textForSizing,
                     style = textStyle,
                     constraints = Constraints(maxWidth = Int.MAX_VALUE)
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,7 @@
     <string name="row_and_repeat_reset_all_message">Are you sure you want to reset the Row and Repeat counters?</string>
     <string name="cd_row_and_repeat_progress">Repeat progress: %1$d of %2$d</string>
     <string name="row_and_repeat_correct_repeat_button">Tap to correct Repeat count manually</string>
+    <string name="row_and_repeat_hide_correct_repeat_button">Hide manual Repeat correction</string>
     <string name="cd_row_and_repeat_correct_repeat_expanded">Manual repeat correction shown</string>
     <string name="cd_row_and_repeat_correct_repeat_collapsed">Manual repeat correction hidden</string>
 </resources>

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/notes/CreateNoteViewModelTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/notes/CreateNoteViewModelTest.kt
@@ -62,7 +62,7 @@ class CreateNoteViewModelTest {
     )
 
     @Test
-    fun `loadNote with null resets to empty create form`() = runTest {
+    fun `loadNote with null preserves create draft across relaunch`() = runTest {
         val viewModel = createViewModel()
         viewModel.updateTitle("Draft title")
         viewModel.updateBody("Draft body")
@@ -71,11 +71,61 @@ class CreateNoteViewModelTest {
 
         val state = viewModel.uiState.value
         assertNull(state.noteId)
-        assertEquals("", state.title)
-        assertEquals("", state.body)
+        assertEquals("Draft title", state.title)
+        assertEquals("Draft body", state.body)
         assertFalse(state.isEditMode)
         assertFalse(state.isLoading)
         assertFalse(state.isSaved)
+    }
+
+    @Test
+    fun `loadNote with null resets after edit mode`() = runTest {
+        coEvery { getNote(7) } returns sampleNote
+        val viewModel = createViewModel()
+        viewModel.loadNote(7)
+        viewModel.updateTitle("Edited title")
+
+        viewModel.loadNote(null)
+
+        val state = viewModel.uiState.value
+        assertNull(state.noteId)
+        assertEquals("", state.title)
+        assertEquals("", state.body)
+        assertFalse(state.isEditMode)
+    }
+
+    @Test
+    fun `loadNote with same id preserves edit draft across relaunch`() = runTest {
+        coEvery { getNote(7) } returns sampleNote
+        val viewModel = createViewModel()
+        viewModel.loadNote(7)
+        viewModel.updateTitle("Edited title")
+        viewModel.updateBody("Edited body")
+
+        viewModel.loadNote(7)
+
+        val state = viewModel.uiState.value
+        assertEquals(7, state.noteId)
+        assertEquals("Edited title", state.title)
+        assertEquals("Edited body", state.body)
+        coVerify(exactly = 1) { getNote(7) }
+    }
+
+    @Test
+    fun `confirmDiscard clears create draft before allowing dismissal`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.updateTitle("Draft title")
+        viewModel.updateBody("Draft body")
+
+        viewModel.dismissalResult.test {
+            viewModel.confirmDiscard()
+            assertEquals(DismissalResult.Allowed, awaitItem())
+        }
+
+        val state = viewModel.uiState.value
+        assertEquals("", state.title)
+        assertEquals("", state.body)
+        assertNull(state.noteId)
     }
 
     @Test
@@ -249,6 +299,43 @@ class CreateNoteViewModelTest {
             viewModel.confirmDiscard()
             assertEquals(DismissalResult.Allowed, awaitItem())
         }
+    }
+
+    @Test
+    fun `loadNote with null after save resets create form`() = runTest {
+        coEvery { createNote("Title", "Body", any()) } returns CreateNoteResult.Success(1L)
+        val viewModel = createViewModel()
+        viewModel.updateTitle("Title")
+        viewModel.updateBody("Body")
+        viewModel.saveNote()
+
+        viewModel.loadNote(null)
+
+        val state = viewModel.uiState.value
+        assertEquals("", state.title)
+        assertEquals("", state.body)
+        assertNull(state.noteId)
+        assertFalse(state.isSaved)
+    }
+
+    @Test
+    fun `loadNote with id after save reloads note from repository`() = runTest {
+        coEvery { getNote(7) } returns sampleNote
+        coEvery { updateNote(7, "New title", "New body", any()) } returns UpdateNoteResult.Success
+        val viewModel = createViewModel()
+        viewModel.loadNote(7)
+        viewModel.updateTitle("New title")
+        viewModel.updateBody("New body")
+        viewModel.saveNote()
+
+        viewModel.loadNote(7)
+
+        val state = viewModel.uiState.value
+        assertEquals(7, state.noteId)
+        assertEquals("Existing title", state.title)
+        assertEquals("Existing body", state.body)
+        assertFalse(state.isSaved)
+        coVerify(exactly = 2) { getNote(7) }
     }
 
     @Test

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterHapticFeedbackTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/sharedComposables/CounterHapticFeedbackTest.kt
@@ -1,6 +1,6 @@
 package dev.harrisonsoftware.stitchCounter.feature.sharedComposables
 
-import android.view.HapticFeedbackConstants
+import android.content.Context
 import android.view.View
 import io.mockk.every
 import io.mockk.mockk
@@ -11,22 +11,34 @@ import org.junit.Test
 class CounterHapticFeedbackTest {
 
     @Test
-    fun `performCounterButtonHapticFeedback triggers context click when enabled`() {
+    fun `performCounterButtonHapticFeedback uses vibrator click when enabled`() {
         val view = mockk<View>(relaxed = true)
-        every { view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK) } returns true
+        val context = mockk<Context>(relaxed = true)
+        every { view.context } returns context
+        var clickVibrationCount = 0
 
-        performCounterButtonHapticFeedback(view, enabled = true)
+        performCounterButtonHapticFeedback(
+            view = view,
+            enabled = true,
+            clickVibration = { clickVibrationCount++ },
+        )
 
-        verify(exactly = 1) { view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK) }
+        assertEquals(1, clickVibrationCount)
     }
 
     @Test
     fun `performCounterButtonHapticFeedback does nothing when disabled`() {
         val view = mockk<View>(relaxed = true)
+        var clickVibrationCount = 0
 
-        performCounterButtonHapticFeedback(view, enabled = false)
+        performCounterButtonHapticFeedback(
+            view = view,
+            enabled = false,
+            clickVibration = { clickVibrationCount++ },
+        )
 
-        verify(exactly = 0) { view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK) }
+        assertEquals(0, clickVibrationCount)
+        verify(exactly = 0) { view.context }
     }
 
     @Test


### PR DESCRIPTION
- Switch counter haptics to the vibrator API so button taps feel consistent across devices
- Add compact sizing helpers for wide/landscape counter layouts
- Keep note create/edit drafts across sheet relaunches, and clear them on discard
- Toggle the correct-repeat button label when the control is expanded