### PR TITLE
Stop library row jitter when closing a counter by keeping library row…

### DIFF
--- a/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectCollection.kt
+++ b/app/src/main/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectCollection.kt
@@ -27,6 +27,11 @@ import androidx.compose.ui.unit.dp
 import dev.harrisonsoftware.stitchCounter.domain.model.Project
 import dev.harrisonsoftware.stitchCounter.feature.navigation.SheetScreen
 
+internal fun shouldEqualizeLibraryProjectHeights(isLandscape: Boolean): Boolean = isLandscape
+
+internal fun tallestLibraryProjectHeightRememberKey(isMultiSelectMode: Boolean): Boolean =
+    isMultiSelectMode
+
 @Composable
 internal fun LibraryProjectCollection(
     projects: List<Project>,
@@ -44,7 +49,9 @@ internal fun LibraryProjectCollection(
     val density = LocalDensity.current
     val lazyListState = rememberLazyListState()
     val lazyGridState = rememberLazyGridState()
-    var tallestProjectHeightPx by remember(projects, isMultiSelectMode) { mutableIntStateOf(0) }
+    var tallestProjectHeightPx by remember(tallestLibraryProjectHeightRememberKey(isMultiSelectMode)) {
+        mutableIntStateOf(0)
+    }
     var projectCountWhenSheetOpened by remember { mutableIntStateOf(-1) }
     var sheetWasOpenedDuringSession by remember { mutableStateOf(false) }
 
@@ -79,13 +86,17 @@ internal fun LibraryProjectCollection(
         }
     }
 
-    val equalHeightModifier = Modifier
-        .heightIn(min = with(density) { tallestProjectHeightPx.toDp() })
-        .onSizeChanged { size ->
-            if (size.height > tallestProjectHeightPx) {
-                tallestProjectHeightPx = size.height
+    val equalHeightModifier = if (shouldEqualizeLibraryProjectHeights(isLandscape)) {
+        Modifier
+            .heightIn(min = with(density) { tallestProjectHeightPx.toDp() })
+            .onSizeChanged { size ->
+                if (size.height > tallestProjectHeightPx) {
+                    tallestProjectHeightPx = size.height
+                }
             }
-        }
+    } else {
+        Modifier
+    }
 
     if (isLandscape) {
         LazyVerticalGrid(

--- a/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectCollectionHeightPolicyTest.kt
+++ b/app/src/test/java/dev/harrisonsoftware/stitchCounter/feature/library/LibraryProjectCollectionHeightPolicyTest.kt
@@ -1,0 +1,25 @@
+package dev.harrisonsoftware.stitchCounter.feature.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibraryProjectCollectionHeightPolicyTest {
+
+    @Test
+    fun shouldEqualizeLibraryProjectHeights_isTrue_inLandscape() {
+        assertTrue(shouldEqualizeLibraryProjectHeights(isLandscape = true))
+    }
+
+    @Test
+    fun shouldEqualizeLibraryProjectHeights_isFalse_inPortrait() {
+        assertFalse(shouldEqualizeLibraryProjectHeights(isLandscape = false))
+    }
+
+    @Test
+    fun tallestLibraryProjectHeightRememberKey_tracksOnlyMultiSelectMode() {
+        assertEquals(false, tallestLibraryProjectHeightRememberKey(isMultiSelectMode = false))
+        assertEquals(true, tallestLibraryProjectHeightRememberKey(isMultiSelectMode = true))
+    }
+}


### PR DESCRIPTION
… heights stable when project data refreshes and skipping equal height reset on library list updates